### PR TITLE
feat: long-lived SSE session

### DIFF
--- a/internal/core/mcpproxy/sse.go
+++ b/internal/core/mcpproxy/sse.go
@@ -128,10 +128,10 @@ func InvokeSSETool(c *gin.Context, conn session.Connection, mcpProxyCfg config.M
 
 	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Minute)
 	defer cancel()
-	c.Request = c.Request.WithContext(ctx)
+	//c.Request = c.Request.WithContext(ctx)
 
 	// Start the transport
-	if err := sseTransport.Start(c.Request.Context()); err != nil {
+	if err := sseTransport.Start(ctx); err != nil {
 		return nil, fmt.Errorf("failed to start SSE transport: %w", err)
 	}
 
@@ -147,7 +147,7 @@ func InvokeSSETool(c *gin.Context, conn session.Connection, mcpProxyCfg config.M
 		Version: version.Get(),
 	}
 
-	_, err = mcpCli.Initialize(c.Request.Context(), initRequest)
+	_, err = mcpCli.Initialize(ctx, initRequest)
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize SSE client: %w", err)
 	}
@@ -163,7 +163,7 @@ func InvokeSSETool(c *gin.Context, conn session.Connection, mcpProxyCfg config.M
 	callRequest.Params.Name = params.Name
 	callRequest.Params.Arguments = toolCallRequestParams
 
-	mcpgoResult, err := mcpCli.CallTool(c.Request.Context(), callRequest)
+	mcpgoResult, err := mcpCli.CallTool(ctx, callRequest)
 	if err != nil {
 		return nil, fmt.Errorf("failed to call tool: %w", err)
 	}

--- a/internal/core/mcpproxy/sse.go
+++ b/internal/core/mcpproxy/sse.go
@@ -163,7 +163,9 @@ func InvokeSSETool(c *gin.Context, conn session.Connection, mcpProxyCfg config.M
 	callRequest.Params.Name = params.Name
 	callRequest.Params.Arguments = toolCallRequestParams
 
+	fmt.Println("before call tool")
 	mcpgoResult, err := mcpCli.CallTool(ctx, callRequest)
+	fmt.Println("after call tool")
 	if err != nil {
 		return nil, fmt.Errorf("failed to call tool: %w", err)
 	}

--- a/internal/core/mcpproxy/sse.go
+++ b/internal/core/mcpproxy/sse.go
@@ -128,9 +128,10 @@ func InvokeSSETool(c *gin.Context, conn session.Connection, mcpProxyCfg config.M
 
 	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Minute)
 	defer cancel()
+	c.Request = c.Request.WithContext(ctx)
 
 	// Start the transport
-	if err := sseTransport.Start(ctx); err != nil {
+	if err := sseTransport.Start(c.Request.Context()); err != nil {
 		return nil, fmt.Errorf("failed to start SSE transport: %w", err)
 	}
 
@@ -146,7 +147,7 @@ func InvokeSSETool(c *gin.Context, conn session.Connection, mcpProxyCfg config.M
 		Version: version.Get(),
 	}
 
-	_, err = mcpCli.Initialize(ctx, initRequest)
+	_, err = mcpCli.Initialize(c.Request.Context(), initRequest)
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize SSE client: %w", err)
 	}
@@ -162,7 +163,7 @@ func InvokeSSETool(c *gin.Context, conn session.Connection, mcpProxyCfg config.M
 	callRequest.Params.Name = params.Name
 	callRequest.Params.Arguments = toolCallRequestParams
 
-	mcpgoResult, err := mcpCli.CallTool(ctx, callRequest)
+	mcpgoResult, err := mcpCli.CallTool(c.Request.Context(), callRequest)
 	if err != nil {
 		return nil, fmt.Errorf("failed to call tool: %w", err)
 	}

--- a/internal/core/sse.go
+++ b/internal/core/sse.go
@@ -553,8 +553,12 @@ func (s *Server) handlePostMessage(c *gin.Context, conn session.Connection) {
 						return
 					}
 				}
+				s.logger.Info("InvokeSSETool",
+					zap.Any("result", result),
+				)
 				s.sendSuccessResponse(c, conn, req, result, true)
 			}()
+			s.logger.Info("return from handlePostMessage")
 			c.String(http.StatusAccepted, mcp.Accepted)
 			return
 		case cnst.BackendProtoStreamable:

--- a/internal/core/sse.go
+++ b/internal/core/sse.go
@@ -522,36 +522,41 @@ func (s *Server) handlePostMessage(c *gin.Context, conn session.Connection) {
 			if len(value) > 0 && len(key) > 0 {
 				mcpProxyCfg.URL += fmt.Sprintf("?%s=%s", key, value)
 			}
-			result, err = mcpproxy.InvokeSSETool(c, conn, mcpProxyCfg, params)
-			if err != nil {
-				s.sendToolExecutionError(c, conn, req, err, true)
-				return
-			}
-			for result != nil && result.IsError {
-				isInvalidKey := false
-				for _, content := range result.Content {
-					if content.GetType() == "text" &&
-						(strings.Contains(content.(*mcp.TextContent).Text, "INVALID_USER_KEY") ||
-							strings.Contains(content.(*mcp.TextContent).Text, "Invalid Key") ||
-							strings.Contains(content.(*mcp.TextContent).Text, "Authentication failed")) {
-						isInvalidKey = true
-						break
-					}
-				}
-				if !isInvalidKey {
-					break
-				}
-				value, err = s.getValidMCPKey(&mcpProxyCfg, true)
-				if err != nil {
-					break
-				}
-				conn.Meta().SetAuthQueryKey(value)
+			go func() {
 				result, err = mcpproxy.InvokeSSETool(c, conn, mcpProxyCfg, params)
 				if err != nil {
 					s.sendToolExecutionError(c, conn, req, err, true)
 					return
 				}
-			}
+				for result != nil && result.IsError {
+					isInvalidKey := false
+					for _, content := range result.Content {
+						if content.GetType() == "text" &&
+							(strings.Contains(content.(*mcp.TextContent).Text, "INVALID_USER_KEY") ||
+								strings.Contains(content.(*mcp.TextContent).Text, "Invalid Key") ||
+								strings.Contains(content.(*mcp.TextContent).Text, "Authentication failed")) {
+							isInvalidKey = true
+							break
+						}
+					}
+					if !isInvalidKey {
+						break
+					}
+					value, err = s.getValidMCPKey(&mcpProxyCfg, true)
+					if err != nil {
+						break
+					}
+					conn.Meta().SetAuthQueryKey(value)
+					result, err = mcpproxy.InvokeSSETool(c, conn, mcpProxyCfg, params)
+					if err != nil {
+						s.sendToolExecutionError(c, conn, req, err, true)
+						return
+					}
+				}
+				s.sendSuccessResponse(c, conn, req, result, true)
+			}()
+			c.String(http.StatusAccepted, mcp.Accepted)
+			return
 		case cnst.BackendProtoStreamable:
 			mcpProxyCfg, ok := s.state.prefixToMCPServerConfig[conn.Meta().Prefix]
 			if !ok {

--- a/internal/core/sse.go
+++ b/internal/core/sse.go
@@ -160,6 +160,9 @@ func (s *Server) handleSSE(c *gin.Context) {
 		zap.String("remote_addr", c.Request.RemoteAddr),
 	)
 
+	ticker := time.NewTicker(30 * time.Second)
+	defer ticker.Stop()
+
 	// Main event loop
 	for {
 		select {
@@ -195,6 +198,16 @@ func (s *Server) handleSSE(c *gin.Context) {
 						zap.String("event_type", event.Event),
 					)
 				}
+			}
+			c.Writer.Flush()
+		case <-ticker.C:
+			_, err := fmt.Fprintf(c.Writer, ": keep-alive\n\n")
+			if err != nil {
+				s.logger.Error("failed to send keep-alive ping",
+					zap.Error(err),
+					zap.String("session_id", sessionID),
+				)
+				return
 			}
 			c.Writer.Flush()
 		case <-c.Request.Context().Done():


### PR DESCRIPTION
1. make downstream SSE session long-lived by sending keep-alive every 30 seconds back to client
2. make upstream SSE session async, so downstream can be able to send keep-alive while waiting for upstream response